### PR TITLE
Add support for private networks

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -44,6 +44,14 @@ gitlab:
     #cloud-config
     package_upgrade: true
 
+  # List of networks this gitlab server is part of. This may be a private
+  # network uuid, or the constant "public" for public networks.
+  #
+  # Note that at least one network entry has to be shared with the gitlab
+  # runner config below, or the runners won't be able to contact the server.
+  networks:
+    - public
+
 # GitLab runner instances settings
 gitlab_runner:
 
@@ -64,6 +72,16 @@ gitlab_runner:
 
   # The size of the root disk
   volume_size_gb: 25
+
+  # The networks attached to the gitlab runner. The first network is used to
+  # communicate with the GitLab server. The GitLab runner typically needs
+  # internet access, so if only private networks are configured, a default
+  # gateway has to be configured.
+  #
+  # The first entry in the list of networks is used to communicate with
+  # the GitLab server.
+  networks:
+    - public
 
   # The user data applied to each instance. Note that GitLab expects to find
   # a working docker configuration.

--- a/config-example.yml
+++ b/config-example.yml
@@ -47,6 +47,9 @@ gitlab:
 # GitLab runner instances settings
 gitlab_runner:
 
+  # The fleeting plugin image to use
+  fleeting_image: quay.io/cloudscalech/fleeting-plugin-cloudscale:latest
+
   # Unique name for this group of managed runner instances
   group: fleeting
 

--- a/config-example.yml
+++ b/config-example.yml
@@ -44,10 +44,10 @@ gitlab:
     #cloud-config
     package_upgrade: true
 
-  # List of networks this gitlab server is part of. This may be a private
+  # List of networks this GitLab server is part of. This may be a private
   # network uuid, or the constant "public" for public networks.
   #
-  # Note that at least one network entry has to be shared with the gitlab
+  # Note that at least one network entry has to be shared with the GitLab
   # runner config below, or the runners won't be able to contact the server.
   networks:
     - public
@@ -73,13 +73,10 @@ gitlab_runner:
   # The size of the root disk
   volume_size_gb: 25
 
-  # The networks attached to the gitlab runner. The first network is used to
+  # The networks attached to the GitLab runner. The first network is used to
   # communicate with the GitLab server. The GitLab runner typically needs
   # internet access, so if only private networks are configured, a default
   # gateway has to be configured.
-  #
-  # The first entry in the list of networks is used to communicate with
-  # the GitLab server.
   networks:
     - public
 
@@ -114,7 +111,7 @@ gitlab_runner:
   # The number of jobs an instance completes, before it is removed
   max_builds: 1024
 
-  # Delete instances when the controlling gitlab runner is shut down. This
+  # Delete instances when the controlling GitLab runner is shut down. This
   # ensures that a new fleeting plugin release causes new runners to be
   # created, but can introduce some instance churn.
   #

--- a/playbooks/gitlab-autoscale.yml
+++ b/playbooks/gitlab-autoscale.yml
@@ -45,6 +45,10 @@
         volume_size_gb: '{{ config.gitlab.volume_size_gb }}'
         ssh_keys: '{{ config.gitlab.ssh_keys }}'
         user_data: '{{ config.gitlab.user_data }}'
+        interfaces: |
+          [{% for network in config.gitlab.networks | default(["public"]) %}
+            {"network": "{{ network }}"}{% if not loop.last %},{% endif %}
+          {% endfor %}]
       register: gitlab_server
       until: gitlab_server.ssh_host_keys
       retries: 60

--- a/templates/gitlab-runner.toml.j2
+++ b/templates/gitlab-runner.toml.j2
@@ -38,6 +38,11 @@ concurrent = {{
   zone = "{{ config.gitlab_runner.zone }}"
   user_data = """{{ config.gitlab_runner.user_data }}"""
   volume_size_gb = {{ config.gitlab_runner.volume_size_gb | default(10) }}
+  interfaces = [
+    {% for network in config.gitlab_runner.networks | default(["public"]) %}
+    { network = "{{ network }}" },
+    {% endfor %}
+  ]
 
 {% for policy in config.gitlab_runner.policies %}
 # {{ policy.name }}

--- a/templates/gitlab-runner.toml.j2
+++ b/templates/gitlab-runner.toml.j2
@@ -15,7 +15,7 @@ concurrent = {{
   use_external_addr = true
 
 [runners.autoscaler]
-  plugin = "quay.io/cloudscalech/fleeting-plugin-cloudscale:latest"
+  plugin = "{{ config.gitlab_runner.fleeting_image | default('quay.io/cloudscalech/fleeting-plugin-cloudscale:latest') }}"
 
   capacity_per_instance = {{ config.gitlab_runner.capacity_per_instance }}
   max_instances = {{ config.gitlab_runner.max_instances }}


### PR DESCRIPTION
To test, use the following image in your config for `gitlab_runner.fleeting_image`:
```yml
# GitLab runner instances settings
gitlab_runner:

  # The fleeting plugin image to use
  fleeting_image: quay.io/cloudscalech/fleeting-plugin-cloudscale-beta:latest
```

You should then be able to create setups where the GitLab Runner communicates via private network:
```yml
gitlab:
  networks:
    - public
    - <private-network-uuid>
 
gitlab_runner:
  networks:
    - <private-network-uuid>
    - public
```

A fully private network should work as well, though you would need a NAT gateway in that case, as the GitLab runner needs internet access.

To test if a job runs, you can create a project with the following `.gitlab-ci.yml`, which is what I usually use:
```yml
image: debian

cache:
  key: global-cache

build:
  script:
    - apt-get update
    - apt-get install -y cowsay
    - >
      test -f cached
      && /usr/games/cowsay "I ran on $CI_RUNNER_DESCRIPTION and found a cache"
      || /usr/games/cowsay "I ran on $CI_RUNNER_DESCRIPTION and found no cache"
    - touch cached
    
  cache:
    paths:
      - cached
```